### PR TITLE
Set default font color to black

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -3,6 +3,11 @@
     border-radius: 0px 0px 5px 5px;
 }
 
+.view text 
+{
+    color: shade(#000000, 2.0);
+}
+
 .view text selection {
     color: shade(#a5b3bc, 1.88);
     background-color: #a5b3bc;


### PR DESCRIPTION
Default font color is very light grey, which makes almost impossible to read text especially on bright background color. Set default color to black. 

See reference images before and after:

![Pinny_before](https://user-images.githubusercontent.com/12559805/107979663-a0177900-6fc7-11eb-9185-391c0a081084.png)
![Pinny_after](https://user-images.githubusercontent.com/12559805/107979670-a3126980-6fc7-11eb-9511-63dfd881d3c6.png)
